### PR TITLE
Update predictive-policing.html

### DIFF
--- a/tactics/predictive-policing.html
+++ b/tactics/predictive-policing.html
@@ -42,9 +42,8 @@
 
     <div class="page-img"><img src="../img/Xtal_4.gif" alt="" style=""></div>
     <div class="page-txt">
-        <h1 class="home-head">License Plate Readers</h1>
-        
-    <h1>Predictive Policing</h1>
+        <h1 class="home-head">Predictive Policing</h1>
+      
     <p>Since 2012, the CPD has used a statistical model to predict the likelihood of someone becoming a “Party to Violence” (PTV), or be involved as either a victim or offender of a violent crime. The model, developed in collaboration with the Illinois Institute of Technology, was initially called the Strategic Subject List (SSL) and was later revised and renamed the Crime and Victimization Risk Model (CVRM). This model was quietly <a id="cvrmlink" href="https://igchicago.org/2020/01/23/advisory-concerning-the-chicago-police-departments-predictive-risk-models/" target="_blank">decommissioned</a> by the CPD in 2019.</p>
 
     <h2>Where</h2>


### PR DESCRIPTION
There was an issue with the h1 header. This page retained the header for "License Plate Readers" and is displaying the header improperly on the website